### PR TITLE
Add cart, search persistence, multi-word search & print

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,26 +6,30 @@ import RecipeDetail from './pages/RecipeDetail';
 import RecipeForm from './pages/RecipeForm';
 import ImportPage from './pages/ImportPage';
 import ShoppingList from './pages/ShoppingList';
+import Cart from './pages/Cart';
 
 export default function App() {
   const location = useLocation();
-  const [selectedIds, setSelectedIds] = useState([]);
+  const [selectedRecipes, setSelectedRecipes] = useState([]);
   const [lang, setLang] = useState(() => localStorage.getItem('lang') || 'en');
 
   const i = t(lang);
+  const selectedIds = selectedRecipes.map((r) => r.id);
 
-  const toggleSelect = (id) => {
-    setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+  const toggleSelect = (id, title) => {
+    setSelectedRecipes((prev) =>
+      prev.some((r) => r.id === id)
+        ? prev.filter((r) => r.id !== id)
+        : [...prev, { id, title }]
     );
   };
 
-  const clearSelection = () => setSelectedIds([]);
+  const clearSelection = () => setSelectedRecipes([]);
 
   const switchLang = (newLang) => {
     setLang(newLang);
     localStorage.setItem('lang', newLang);
-    setSelectedIds([]);
+    setSelectedRecipes([]);
   };
 
   return (
@@ -42,6 +46,15 @@ export default function App() {
             </Link>
             <Link to="/import" className={location.pathname === '/import' ? 'active' : ''}>
               {i.import}
+            </Link>
+            <Link to="/cart" className={`cart-icon-link ${location.pathname === '/cart' ? 'active' : ''}`}>
+              <svg className="cart-icon-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/>
+                <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/>
+              </svg>
+              {selectedIds.length > 0 && (
+                <span className="cart-badge">{selectedIds.length}</span>
+              )}
             </Link>
             <div className="lang-toggle">
               <button
@@ -74,10 +87,23 @@ export default function App() {
               />
             }
           />
-          <Route path="/recipe/:id" element={<RecipeDetail lang={lang} />} />
+          <Route path="/recipe/:id" element={<RecipeDetail lang={lang} selectedIds={selectedIds} onToggleSelect={toggleSelect} />} />
           <Route path="/add" element={<RecipeForm lang={lang} />} />
           <Route path="/edit/:id" element={<RecipeForm lang={lang} />} />
           <Route path="/import" element={<ImportPage lang={lang} />} />
+          <Route
+            path="/cart"
+            element={
+              <Cart
+                lang={lang}
+                selectedRecipes={selectedRecipes}
+                selectedIds={selectedIds}
+                onToggleSelect={toggleSelect}
+                onClearSelection={clearSelection}
+                onLoadPlan={(recipes) => setSelectedRecipes(recipes)}
+              />
+            }
+          />
           <Route
             path="/shopping-list"
             element={<ShoppingList selectedIds={selectedIds} onClear={clearSelection} lang={lang} />}

--- a/client/src/i18n.js
+++ b/client/src/i18n.js
@@ -35,6 +35,20 @@ const translations = {
     ingredients: 'Ingredients',
     instructions: 'Instructions',
     backToRecipes: 'Back to recipes',
+    selectRecipe: 'Select',
+    selectedLabel: 'Selected',
+    printRecipe: 'Print',
+    remove: 'Remove',
+
+    // Cart & saved meal plans
+    mySelection: 'My Selection',
+    cartEmpty: 'No recipes selected and no saved plans. Browse recipes and select some!',
+    savePlan: 'Save plan',
+    savedPlans: 'Saved plans',
+    planName: 'Plan name',
+    loadPlan: 'Load',
+    deletePlan: 'Delete',
+    confirmDeletePlan: (name) => `Delete plan "${name}"?`,
 
     // RecipeForm
     editRecipe: 'Edit Recipe',
@@ -137,6 +151,20 @@ const translations = {
     ingredients: 'Ingredients',
     instructions: 'Instructions',
     backToRecipes: 'Retour aux recettes',
+    selectRecipe: 'Selectionner',
+    selectedLabel: 'Selectionnee',
+    printRecipe: 'Imprimer',
+    remove: 'Retirer',
+
+    // Cart & saved meal plans
+    mySelection: 'Ma selection',
+    cartEmpty: 'Aucune recette selectionnee et aucun plan sauvegarde. Parcourez les recettes!',
+    savePlan: 'Sauvegarder le plan',
+    savedPlans: 'Plans sauvegardes',
+    planName: 'Nom du plan',
+    loadPlan: 'Charger',
+    deletePlan: 'Supprimer',
+    confirmDeletePlan: (name) => `Supprimer le plan "${name}"?`,
 
     // RecipeForm
     editRecipe: 'Modifier la recette',

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -661,29 +661,119 @@ button {
   border-color: var(--primary);
 }
 
-/* Selection bar */
-.selection-bar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background: var(--primary-dark);
+/* Cart icon in header */
+.cart-icon-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 8px 12px !important;
+}
+
+.cart-icon-svg {
+  width: 20px;
+  height: 20px;
+}
+
+.cart-badge {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  background: var(--danger);
   color: white;
-  padding: 14px 24px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+/* Cart page */
+.cart-page {
+  max-width: 800px;
+  margin: 24px auto;
+}
+
+.cart-page h2 {
+  margin-bottom: 20px;
+}
+
+.cart-empty {
+  text-align: center;
+  padding: 48px 0;
+  color: var(--text-light);
+}
+
+.cart-empty .btn {
+  margin-top: 16px;
+}
+
+.cart-section {
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.cart-section h3 {
+  margin: 0 0 16px;
+}
+
+.cart-section-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  z-index: 200;
-  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.15);
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
-.selection-bar button {
-  background: white;
+.cart-section-header h3 {
+  margin: 0;
+}
+
+.cart-recipe-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.cart-recipe-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+  gap: 12px;
+}
+
+.cart-recipe-item:last-child {
+  border-bottom: none;
+}
+
+.cart-recipe-title {
+  flex: 1;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.cart-recipe-title:hover {
   color: var(--primary-dark);
-  border: none;
-  padding: 8px 20px;
-  border-radius: 8px;
-  font-weight: 600;
+}
+
+.cart-save-section {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.cart-save-section h4 {
+  margin: 0 0 8px;
+  font-size: 0.9rem;
 }
 
 .tags-list {
@@ -701,9 +791,272 @@ button {
   color: var(--text-light);
 }
 
-/* Floating action button for shopping list */
-.fab-container {
-  padding-bottom: 70px;
+.cart-save-row {
+  display: flex;
+  gap: 8px;
+  padding: 8px 24px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cart-save-row input {
+  flex: 1;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-family: inherit;
+}
+
+.cart-save-row input:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+.cart-save-row button {
+  padding: 6px 14px;
+  background: var(--primary);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.cart-save-row button:hover {
+  background: var(--primary-dark);
+}
+
+.saved-plans-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.saved-plan-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  gap: 12px;
+}
+
+.saved-plan-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.saved-plan-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.saved-plan-meta {
+  font-size: 0.8rem;
+  color: var(--text-light);
+  margin-top: 2px;
+}
+
+.saved-plan-recipes {
+  font-size: 0.8rem;
+  color: var(--text-light);
+  margin-top: 4px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.saved-plan-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.saved-plan-actions .delete-plan {
+  color: var(--text-light) !important;
+}
+
+.saved-plan-actions .delete-plan:hover {
+  border-color: var(--danger) !important;
+  color: var(--danger) !important;
+}
+
+/* Print-only layout (hidden on screen) */
+.print-only {
+  display: none;
+}
+
+/* Print styles */
+@media print {
+  .header,
+  .no-print {
+    display: none !important;
+  }
+
+  .print-only {
+    display: block !important;
+  }
+
+  body {
+    background: white;
+    font-size: 10pt;
+    line-height: 1.3;
+    margin: 0;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .container {
+    max-width: 100%;
+    padding: 0;
+    margin: 0;
+  }
+
+  /* PAGE 1: Cover — hero image + ingredients sidebar */
+  .print-page-1 {
+    page-break-after: always;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .print-cover {
+    display: flex;
+    height: 100%;
+  }
+
+  .print-hero {
+    width: 58%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .print-sidebar {
+    width: 42%;
+    padding: 24px 20px;
+    display: flex;
+    flex-direction: column;
+    background: #fafafa;
+    overflow: hidden;
+  }
+
+  .print-title {
+    font-size: 1.4rem;
+    font-weight: 700;
+    margin: 0 0 8px;
+    color: #2c3e50;
+    line-height: 1.2;
+  }
+
+  .print-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 2px solid #91c03d;
+  }
+
+  .print-meta span {
+    font-size: 0.7rem;
+    background: #eee;
+    padding: 2px 8px;
+    border-radius: 10px;
+    color: #555;
+  }
+
+  .print-section-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #91c03d;
+    margin: 0 0 8px;
+  }
+
+  .print-ingredients {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    flex: 1;
+  }
+
+  .print-ingredients li {
+    padding: 4px 0;
+    border-bottom: 1px solid #eee;
+    font-size: 0.8rem;
+    line-height: 1.3;
+  }
+
+  .print-ingredients li:last-child {
+    border-bottom: none;
+  }
+
+  .print-ingredients li strong {
+    color: #91c03d;
+    font-weight: 600;
+  }
+
+  /* PAGE 2: Steps grid with thumbnails */
+  .print-page-2 {
+    padding: 20px;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .print-steps-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+  }
+
+  .print-step {
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    padding: 8px;
+    page-break-inside: avoid;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .print-step-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .print-step-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    min-width: 22px;
+    background: #91c03d;
+    color: white;
+    border-radius: 50%;
+    font-size: 0.7rem;
+    font-weight: 700;
+  }
+
+  .print-step-img {
+    width: 90px;
+    height: 60px;
+    object-fit: cover;
+    border-radius: 4px;
+    margin-left: auto;
+  }
+
+  .print-step-text {
+    font-size: 0.72rem;
+    line-height: 1.3;
+    margin: 0;
+    color: #333;
+  }
 }
 
 /* Responsive */

--- a/client/src/pages/Cart.jsx
+++ b/client/src/pages/Cart.jsx
@@ -1,0 +1,139 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { t as getT } from '../i18n';
+
+const PLANS_KEY = 'mealPlans';
+
+function loadSavedPlans() {
+  try {
+    return JSON.parse(localStorage.getItem(PLANS_KEY)) || [];
+  } catch {
+    return [];
+  }
+}
+
+function persistPlans(plans) {
+  localStorage.setItem(PLANS_KEY, JSON.stringify(plans));
+}
+
+export default function Cart({ lang, selectedRecipes, selectedIds, onToggleSelect, onClearSelection, onLoadPlan }) {
+  const i = getT(lang);
+  const navigate = useNavigate();
+  const [savedPlans, setSavedPlans] = useState(loadSavedPlans);
+  const [planName, setPlanName] = useState('');
+
+  const savePlan = () => {
+    const name = planName.trim();
+    if (!name || selectedRecipes.length === 0) return;
+    const plan = {
+      id: Date.now(),
+      name,
+      recipes: [...selectedRecipes],
+      date: new Date().toLocaleDateString(),
+    };
+    const updated = [plan, ...savedPlans];
+    setSavedPlans(updated);
+    persistPlans(updated);
+    setPlanName('');
+  };
+
+  const loadPlan = (plan) => {
+    onLoadPlan(plan.recipes);
+  };
+
+  const deletePlan = (planId) => {
+    if (!window.confirm(i.confirmDeletePlan ? i.confirmDeletePlan('plan') : 'Delete this plan?')) return;
+    const updated = savedPlans.filter((p) => p.id !== planId);
+    setSavedPlans(updated);
+    persistPlans(updated);
+  };
+
+  return (
+    <div className="cart-page">
+      <h2>{i.mySelection}</h2>
+
+      {selectedIds.length === 0 && savedPlans.length === 0 && (
+        <div className="cart-empty">
+          <p>{i.cartEmpty}</p>
+          <Link to="/" className="btn btn-primary">{i.browseRecipes}</Link>
+        </div>
+      )}
+
+      {selectedIds.length > 0 && (
+        <div className="cart-section">
+          <div className="cart-section-header">
+            <h3>{i.selected(selectedIds.length)}</h3>
+            <div style={{ display: 'flex', gap: '8px' }}>
+              <button className="btn btn-outline btn-sm" onClick={onClearSelection}>{i.clearAll}</button>
+              <button
+                className="btn btn-primary btn-sm"
+                onClick={() => navigate('/shopping-list')}
+              >
+                {i.genList}
+              </button>
+            </div>
+          </div>
+
+          <ul className="cart-recipe-list">
+            {selectedRecipes.map((r) => (
+              <li key={r.id} className="cart-recipe-item">
+                <Link to={`/recipe/${r.id}`} className="cart-recipe-title">
+                  {r.title}
+                </Link>
+                <button
+                  className="btn btn-outline btn-sm"
+                  onClick={() => onToggleSelect(r.id, r.title)}
+                >
+                  {i.remove}
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          <div className="cart-save-section">
+            <h4>{i.savePlan}</h4>
+            <div className="cart-save-row">
+              <input
+                type="text"
+                value={planName}
+                onChange={(e) => setPlanName(e.target.value)}
+                placeholder={i.planName}
+                onKeyDown={(e) => e.key === 'Enter' && savePlan()}
+              />
+              <button onClick={savePlan}>{i.savePlan}</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {savedPlans.length > 0 && (
+        <div className="cart-section">
+          <h3>{i.savedPlans}</h3>
+          <div className="saved-plans-list">
+            {savedPlans.map((plan) => (
+              <div key={plan.id} className="saved-plan-card">
+                <div className="saved-plan-info">
+                  <div className="saved-plan-name">{plan.name}</div>
+                  <div className="saved-plan-meta">
+                    {plan.recipes.length} {i.recipes.toLowerCase()} — {plan.date}
+                  </div>
+                  <div className="saved-plan-recipes">
+                    {plan.recipes.map((r) => r.title).join(', ')}
+                  </div>
+                </div>
+                <div className="saved-plan-actions">
+                  <button className="btn btn-outline btn-sm" onClick={() => loadPlan(plan)}>
+                    {i.loadPlan}
+                  </button>
+                  <button className="btn btn-outline btn-sm delete-plan" onClick={() => deletePlan(plan.id)}>
+                    {i.deletePlan}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/RecipeDetail.jsx
+++ b/client/src/pages/RecipeDetail.jsx
@@ -1,13 +1,16 @@
 import { useState, useEffect } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 import { fetchRecipe, deleteRecipe } from '../api';
 import { t } from '../i18n';
 
-export default function RecipeDetail({ lang }) {
+export default function RecipeDetail({ lang, selectedIds = [], onToggleSelect }) {
   const { id } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+  const canGoBack = location.key !== 'default';
   const [recipe, setRecipe] = useState(null);
   const i = t(lang);
+  const isSelected = recipe ? selectedIds.includes(recipe.id) : false;
 
   useEffect(() => {
     fetchRecipe(id).then(setRecipe);
@@ -25,77 +28,136 @@ export default function RecipeDetail({ lang }) {
   };
 
   return (
-    <div className="recipe-detail">
-      {recipe.imageUrl && (
-        <img src={recipe.imageUrl} alt={recipe.title} className="hero-image" />
-      )}
-      <div className="recipe-detail-content">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '16px', flexWrap: 'wrap' }}>
-          <h2>{recipe.title}</h2>
-          <div className="btn-group">
-            <Link to={`/edit/${recipe.id}`} className="btn btn-outline btn-sm">
-              {i.edit}
-            </Link>
-            <button onClick={handleDelete} className="btn btn-danger btn-sm">
-              {i.delete}
+    <>
+      {/* === SCREEN LAYOUT (hidden when printing) === */}
+      <div className="recipe-detail no-print">
+        {recipe.imageUrl && (
+          <img src={recipe.imageUrl} alt={recipe.title} className="hero-image" />
+        )}
+        <div className="recipe-detail-content">
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '16px', flexWrap: 'wrap' }}>
+            <h2>{recipe.title}</h2>
+            <div className="btn-group">
+              <button
+                onClick={() => onToggleSelect(recipe.id, recipe.title)}
+                className={`btn btn-sm ${isSelected ? 'btn-primary' : 'btn-outline'}`}
+              >
+                {isSelected ? `✓ ${i.selectedLabel}` : i.selectRecipe}
+              </button>
+              <button onClick={() => window.print()} className="btn btn-outline btn-sm">
+                {i.printRecipe}
+              </button>
+              <Link to={`/edit/${recipe.id}`} className="btn btn-outline btn-sm">
+                {i.edit}
+              </Link>
+              <button onClick={handleDelete} className="btn btn-danger btn-sm">
+                {i.delete}
+              </button>
+            </div>
+          </div>
+
+          {recipe.description && <p style={{ color: 'var(--text-light)' }}>{recipe.description}</p>}
+
+          <div className="meta-row">
+            {recipe.servings && <span className="meta-badge">{i.servings(recipe.servings)}</span>}
+            {recipe.prepTime && <span className="meta-badge">{i.prep}: {recipe.prepTime.replace('PT', '').toLowerCase()}</span>}
+            {recipe.totalTime && <span className="meta-badge">{i.total}: {recipe.totalTime.replace('PT', '').toLowerCase()}</span>}
+            {recipe.difficulty && <span className="meta-badge">{recipe.difficulty}</span>}
+            {recipe.cuisine && <span className="meta-badge">{recipe.cuisine}</span>}
+          </div>
+
+          {recipe.tags?.length > 0 && (
+            <div className="tags-list" style={{ marginBottom: '12px' }}>
+              {recipe.tags.map((tag) => (
+                <span key={tag} className="tag">{tag}</span>
+              ))}
+            </div>
+          )}
+
+          {recipe.sourceUrl && (
+            <p style={{ fontSize: '0.85rem' }}>
+              <a href={recipe.sourceUrl} target="_blank" rel="noopener noreferrer">
+                {i.viewOriginal}
+              </a>
+            </p>
+          )}
+
+          <h3>{i.ingredients}</h3>
+          <ul className="ingredients-list">
+            {recipe.ingredients.map((ing) => (
+              <li key={ing.id}>
+                <span className="amount">
+                  {ing.amount} {ing.unit}
+                </span>{' '}
+                {ing.name}
+              </li>
+            ))}
+          </ul>
+
+          <h3>{i.instructions}</h3>
+          <ol className="steps-list">
+            {recipe.steps.map((step) => (
+              <li key={step.id}>
+                {step.instruction}
+                {step.imageUrl && <img src={step.imageUrl} alt={`${i.steps} ${step.stepNumber}`} loading="lazy" />}
+              </li>
+            ))}
+          </ol>
+
+          <div style={{ marginTop: '32px' }}>
+            <button onClick={() => canGoBack ? navigate(-1) : navigate('/')} className="btn btn-outline">
+              {i.backToRecipes}
             </button>
           </div>
         </div>
+      </div>
 
-        {recipe.description && <p style={{ color: 'var(--text-light)' }}>{recipe.description}</p>}
-
-        <div className="meta-row">
-          {recipe.servings && <span className="meta-badge">{i.servings(recipe.servings)}</span>}
-          {recipe.prepTime && <span className="meta-badge">{i.prep}: {recipe.prepTime.replace('PT', '').toLowerCase()}</span>}
-          {recipe.totalTime && <span className="meta-badge">{i.total}: {recipe.totalTime.replace('PT', '').toLowerCase()}</span>}
-          {recipe.difficulty && <span className="meta-badge">{recipe.difficulty}</span>}
-          {recipe.cuisine && <span className="meta-badge">{recipe.cuisine}</span>}
+      {/* === PRINT LAYOUT (only visible when printing) === */}
+      <div className="print-only">
+        {/* PAGE 1: Hero image + ingredients */}
+        <div className="print-page-1">
+          <div className="print-cover">
+            {recipe.imageUrl && (
+              <img src={recipe.imageUrl} alt={recipe.title} className="print-hero" />
+            )}
+            <div className="print-sidebar">
+              <h1 className="print-title">{recipe.title}</h1>
+              <div className="print-meta">
+                {recipe.servings && <span>{i.servings(recipe.servings)}</span>}
+                {recipe.prepTime && <span>{i.prep}: {recipe.prepTime.replace('PT', '').toLowerCase()}</span>}
+                {recipe.totalTime && <span>{i.total}: {recipe.totalTime.replace('PT', '').toLowerCase()}</span>}
+                {recipe.difficulty && <span>{recipe.difficulty}</span>}
+              </div>
+              <h2 className="print-section-title">{i.ingredients}</h2>
+              <ul className="print-ingredients">
+                {recipe.ingredients.map((ing) => (
+                  <li key={ing.id}>
+                    <strong>{ing.amount} {ing.unit}</strong> {ing.name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
         </div>
 
-        {recipe.tags?.length > 0 && (
-          <div className="tags-list" style={{ marginBottom: '12px' }}>
-            {recipe.tags.map((tag) => (
-              <span key={tag} className="tag">{tag}</span>
+        {/* PAGE 2: Steps with thumbnails */}
+        <div className="print-page-2">
+          <h2 className="print-section-title" style={{ marginBottom: '12px' }}>{i.instructions}</h2>
+          <div className="print-steps-grid">
+            {recipe.steps.map((step) => (
+              <div key={step.id} className="print-step">
+                <div className="print-step-header">
+                  <span className="print-step-num">{step.stepNumber}</span>
+                  {step.imageUrl && (
+                    <img src={step.imageUrl} alt="" className="print-step-img" />
+                  )}
+                </div>
+                <p className="print-step-text">{step.instruction}</p>
+              </div>
             ))}
           </div>
-        )}
-
-        {recipe.sourceUrl && (
-          <p style={{ fontSize: '0.85rem' }}>
-            <a href={recipe.sourceUrl} target="_blank" rel="noopener noreferrer">
-              {i.viewOriginal}
-            </a>
-          </p>
-        )}
-
-        <h3>{i.ingredients}</h3>
-        <ul className="ingredients-list">
-          {recipe.ingredients.map((ing) => (
-            <li key={ing.id}>
-              <span className="amount">
-                {ing.amount} {ing.unit}
-              </span>{' '}
-              {ing.name}
-            </li>
-          ))}
-        </ul>
-
-        <h3>{i.instructions}</h3>
-        <ol className="steps-list">
-          {recipe.steps.map((step) => (
-            <li key={step.id}>
-              {step.instruction}
-              {step.imageUrl && <img src={step.imageUrl} alt={`${i.steps} ${step.stepNumber}`} loading="lazy" />}
-            </li>
-          ))}
-        </ol>
-
-        <div style={{ marginTop: '32px' }}>
-          <Link to="/" className="btn btn-outline">
-            {i.backToRecipes}
-          </Link>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/client/src/pages/RecipeList.jsx
+++ b/client/src/pages/RecipeList.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
 import { fetchRecipes, fetchTags } from '../api';
 import { t as getT } from '../i18n';
 
@@ -15,14 +15,16 @@ const FILTERS = {
 };
 
 export default function RecipeList({ lang, selectedIds, onToggleSelect, onClearSelection }) {
-  const [query, setQuery] = useState('');
-  const [activeSearch, setActiveSearch] = useState('');
-  const [activeTags, setActiveTags] = useState([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeSearch = searchParams.get('search') || '';
+  const activeTagsStr = searchParams.get('tags') || '';
+  const activeTags = activeTagsStr ? activeTagsStr.split(',') : [];
+  const page = parseInt(searchParams.get('page') || '1');
+
+  const [query, setQuery] = useState(activeSearch);
   const [availableTags, setAvailableTags] = useState({ meals: [], cuisines: [] });
   const [results, setResults] = useState(null);
   const [loading, setLoading] = useState(false);
-  const [page, setPage] = useState(1);
-  const navigate = useNavigate();
   const i = getT(lang);
 
   // Load tags dynamically for the current language
@@ -50,14 +52,31 @@ export default function RecipeList({ lang, selectedIds, onToggleSelect, onClearS
     });
   }, [lang]);
 
+  // Helper to update URL search params
+  const updateParams = useCallback((updates) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      for (const [key, value] of Object.entries(updates)) {
+        if (value === null || value === '' || (value === '1' && key === 'page')) {
+          next.delete(key);
+        } else {
+          next.set(key, value);
+        }
+      }
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
+
   // Reset search when language changes
+  const prevLangRef = useRef(lang);
   useEffect(() => {
-    setQuery('');
-    setActiveSearch('');
-    setActiveTags([]);
-    setResults(null);
-    setPage(1);
-  }, [lang]);
+    if (prevLangRef.current !== lang) {
+      prevLangRef.current = lang;
+      setQuery('');
+      setSearchParams({}, { replace: true });
+      setResults(null);
+    }
+  }, [lang, setSearchParams]);
 
   const doSearch = useCallback(async (searchTerm, tags, pageNum, language) => {
     if (!searchTerm && tags.length === 0) {
@@ -76,28 +95,27 @@ export default function RecipeList({ lang, selectedIds, onToggleSelect, onClearS
   }, []);
 
   useEffect(() => {
-    if (activeSearch || activeTags.length > 0) {
+    if (activeSearch || activeTagsStr) {
       doSearch(activeSearch, activeTags, page, lang);
     }
-  }, [activeSearch, activeTags, page, lang, doSearch]);
+  }, [activeSearch, activeTagsStr, page, lang, doSearch]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    setPage(1);
-    setActiveSearch(query.trim());
+    updateParams({ search: query.trim(), page: '1' });
   };
 
   const toggleTag = (tag) => {
-    setPage(1);
-    setActiveTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
-    );
+    const newTags = activeTags.includes(tag)
+      ? activeTags.filter((t) => t !== tag)
+      : [...activeTags, tag];
+    updateParams({ tags: newTags.join(',') || null, page: '1' });
   };
 
   const hasSearched = activeSearch || activeTags.length > 0;
 
   return (
-    <div className={selectedIds.length > 0 ? 'fab-container' : ''}>
+    <div>
       <div className={`search-hero ${hasSearched ? 'search-hero--compact' : ''}`}>
         <h2 className="search-hero-title">{i.heroTitle}</h2>
         <form onSubmit={handleSubmit} className="search-form">
@@ -169,10 +187,8 @@ export default function RecipeList({ lang, selectedIds, onToggleSelect, onClearS
               className="btn btn-outline btn-sm"
               onClick={() => {
                 setQuery('');
-                setActiveSearch('');
-                setActiveTags([]);
+                setSearchParams({}, { replace: true });
                 setResults(null);
-                setPage(1);
               }}
             >
               {i.clearAll}
@@ -191,7 +207,7 @@ export default function RecipeList({ lang, selectedIds, onToggleSelect, onClearS
                     className={`select-checkbox ${selectedIds.includes(recipe.id) ? 'selected' : ''}`}
                     onClick={(e) => {
                       e.stopPropagation();
-                      onToggleSelect(recipe.id);
+                      onToggleSelect(recipe.id, recipe.title);
                     }}
                   >
                     {selectedIds.includes(recipe.id) ? '\u2713' : ''}
@@ -226,11 +242,11 @@ export default function RecipeList({ lang, selectedIds, onToggleSelect, onClearS
 
           {results.totalPages > 1 && (
             <div className="pagination">
-              <button className="btn btn-outline btn-sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+              <button className="btn btn-outline btn-sm" disabled={page <= 1} onClick={() => updateParams({ page: String(page - 1) })}>
                 {i.previous}
               </button>
               <span className="page-info">{i.page(results.page, results.totalPages)}</span>
-              <button className="btn btn-outline btn-sm" disabled={page >= results.totalPages} onClick={() => setPage((p) => p + 1)}>
+              <button className="btn btn-outline btn-sm" disabled={page >= results.totalPages} onClick={() => updateParams({ page: String(page + 1) })}>
                 {i.next}
               </button>
             </div>
@@ -238,20 +254,6 @@ export default function RecipeList({ lang, selectedIds, onToggleSelect, onClearS
         </>
       )}
 
-      {selectedIds.length > 0 && (
-        <div className="selection-bar">
-          <span>{i.selected(selectedIds.length)}</span>
-          <div style={{ display: 'flex', gap: '8px' }}>
-            <button onClick={onClearSelection}>{i.clear}</button>
-            <button
-              onClick={() => navigate('/shopping-list')}
-              style={{ background: 'var(--primary)', color: 'white' }}
-            >
-              {i.genList}
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -64,14 +64,17 @@ router.get('/', async (req, res) => {
     const where = { AND: [{ language: lang }] };
 
     if (search) {
-      where.AND.push({
-        OR: [
-          { title: { contains: search, mode: 'insensitive' } },
-          { description: { contains: search, mode: 'insensitive' } },
-          { cuisine: { contains: search, mode: 'insensitive' } },
-          { ingredients: { some: { name: { contains: search, mode: 'insensitive' } } } },
-        ],
-      });
+      const words = search.trim().split(/\s+/).filter(Boolean);
+      for (const word of words) {
+        where.AND.push({
+          OR: [
+            { title: { contains: word, mode: 'insensitive' } },
+            { description: { contains: word, mode: 'insensitive' } },
+            { cuisine: { contains: word, mode: 'insensitive' } },
+            { ingredients: { some: { name: { contains: word, mode: 'insensitive' } } } },
+          ],
+        });
+      }
     }
 
     if (tags) {


### PR DESCRIPTION
## Summary
- **Cart page** (`/cart`) with shopping cart icon + badge in header nav, replacing the old bottom selection bar
- **Save/load meal plans** to localStorage — name a selection, come back to it later
- **Select recipes from detail page** — new Select button alongside Edit/Delete
- **Search persistence** — search state stored in URL params (`?search=chicken&tags=Quick`), so navigating to a recipe and pressing back preserves results
- **Multi-word full-text search fix** — "chicken pasta" now finds recipes containing both words (AND logic per word across title/description/cuisine/ingredients)
- **HelloFresh-style print layout** — Page 1: hero image + ingredients sidebar; Page 2: steps in 2-column grid with thumbnails
- **Bilingual** (EN/FR) for all new UI strings

## Test plan
- [ ] Search for multi-word queries (e.g. "chicken pasta") and verify results contain both words
- [ ] Click a filter chip, navigate to a recipe detail, press Back — search results should still be there
- [ ] Select recipes from both the list (checkbox) and detail page (Select button) — cart badge updates
- [ ] Visit `/cart`, verify selected recipes listed with Remove buttons
- [ ] Save a plan with a name, clear selection, reload page — saved plan persists
- [ ] Load a saved plan — selection restored
- [ ] On a recipe detail page, click Print — verify 2-page HelloFresh-style layout
- [ ] Switch language to FR and verify all new strings are translated

🤖 Generated with [Claude Code](https://claude.com/claude-code)