### PR TITLE
fix(security): patch effect and path-to-regexp CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -717,9 +717,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1509,9 +1509,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathe": {

--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
   "devDependencies": {
     "concurrently": "^9.1.2",
     "prisma": "^6.4.1"
+  },
+  "overrides": {
+    "path-to-regexp@0.1.12": "0.1.13",
+    "effect": "^3.20.0"
   }
 }


### PR DESCRIPTION
## Summary
- **CVE-2026-32887**: `effect` AsyncLocalStorage context contamination under concurrent load — overridden from 3.18.4 to ^3.20.0 (resolved 3.21.0)
- **CVE-2026-4867**: `path-to-regexp` ReDoS via malformed URL parameters — overridden from 0.1.12 to 0.1.13

Both are transitive dependencies (effect via prisma/@prisma/config, path-to-regexp via express), so npm `overrides` were used in package.json.

## Test plan
- [ ] No test suite exists; verify app starts correctly after merge
- [ ] Confirm `npm ls path-to-regexp` shows 0.1.13
- [ ] Confirm `npm ls effect` shows >= 3.20.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)