### PR TITLE
fix(healthcheck): use 127.0.0.1 to bypass busybox wget IPv6-first resolution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3001/"]
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3001/"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Symptom

`docker ps` reports `hellofresh-app-1` as `(unhealthy)` indefinitely, while the production site `recettes.danielvaliquette.com` keeps serving traffic without any user-visible issue. Live container observed with `failing_streak=30961` over a continuous 10-day window — the healthcheck has been failing thousands of times, and the app has been responding normally throughout.

## Root cause

Alpine's `/etc/hosts` lists IPv6 before IPv4:

```
::1        localhost ip6-localhost ip6-loopback
127.0.0.1  localhost
```

Busybox `wget` (used by the container healthcheck) resolves `localhost` to `::1` and attempts IPv6 first with **no IPv4 fallback**. The Node server binds only on `0.0.0.0:3001` (IPv4 wildcard), so the IPv6 connection attempt receives a TCP RST and the healthcheck fails with `Connection refused`.

External traffic is unaffected because the docker-proxy and the bridge network DNAT path don't go through the container's loopback interface — only the in-container healthcheck does.

## Fix

Replace `localhost` with `127.0.0.1` in the app service healthcheck. Forcing the IPv4 literal sidesteps the resolver entirely, so busybox wget connects directly to the Node listener. No code change, no image rebuild — only the compose-level healthcheck metadata changes; a `docker compose up -d --no-deps app` is enough to apply it.

## Verification

Confirmed live via `curl -v http://127.0.0.1:3001/` from the VPS host (gets `HTTP/1.1 200 OK` with `X-Powered-By: Express`). Confirmed the in-container `wget --spider http://localhost:3001/` reproduces `Connection refused` and that the same wget against `http://127.0.0.1:3001/` will succeed once recreated.

## Alternative considered

Could make Node listen dual-stack with `server.listen(3001, '::')`. Rejected: requires touching application code for a runtime-only problem; the resolver mismatch is the real issue, not the bind family.