### PR TITLE
fix(scrape-all): pass existingTitles to scrapeSegment

### DIFF
--- a/server/routes/import.js
+++ b/server/routes/import.js
@@ -197,7 +197,7 @@ async function countSegment(token, baseUrl, extraParams = '') {
   return data?.total || 0;
 }
 
-async function scrapeSegment(token, config, lang, baseUrl, extraParams, existingUrls, maxRecipes) {
+async function scrapeSegment(token, config, lang, baseUrl, extraParams, existingUrls, existingTitles, maxRecipes) {
   let offset = 0;
   const segTotal = await countSegment(token, baseUrl, extraParams);
   const cap = Math.min(segTotal, API_MAX_OFFSET, maxRecipes > 0 ? maxRecipes : Infinity);
@@ -324,7 +324,7 @@ router.post('/hellofresh/scrape-all', async (req, res) => {
         scrapeStatus.segment = `${i + 1}/${segments.length}: ${seg.label}`;
         scrapeStatus.segmentsCompleted = i;
 
-        token = await scrapeSegment(token, config, lang, baseUrl, seg.params, existingUrls, limit);
+        token = await scrapeSegment(token, config, lang, baseUrl, seg.params, existingUrls, existingTitles, limit);
       }
 
       scrapeStatus.segmentsCompleted = segments.length;


### PR DESCRIPTION
## Summary
- Closes a silent failure introduced in a2f9bc8: `scrapeSegment` referenced `existingTitles` from the IIFE scope of `/scrape-all`, so every recipe threw `ReferenceError` (caught by the inner try, pushed into `errors[]`).
- Fix: thread `existingTitles` through `scrapeSegment`'s signature. Two-line change.

## Why this was hidden
The inner `try/catch` around the per-recipe loop pushed each error to `scrapeStatus.errors[]` and incremented `failed`. The scrape appeared to "run" — total/progress moved — but the dedup branch threw before any insert, so `imported` stayed at 0 and the catalog never got into Postgres.

## Test plan
- [ ] Start the app (Docker or local)
- [ ] Trigger Scrape All from the Import page (small `limit`, e.g. 20)
- [ ] Confirm `imported` increments and recipes appear in the search

🤖 Generated with [Claude Code](https://claude.com/claude-code)