### PR TITLE
feat(pantry): /pantry — find recipes by available ingredients

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,7 @@ import RecipeForm from './pages/RecipeForm';
 import ImportPage from './pages/ImportPage';
 import ShoppingList from './pages/ShoppingList';
 import Cart from './pages/Cart';
+import PantryPage from './pages/PantryPage';
 
 export default function App() {
   const location = useLocation();
@@ -39,6 +40,9 @@ export default function App() {
           <nav className="nav-links">
             <Link to="/" className={location.pathname === '/' ? 'active' : ''}>
               {i.recipes}
+            </Link>
+            <Link to="/pantry" className={location.pathname === '/pantry' ? 'active' : ''}>
+              {i.pantry}
             </Link>
             <Link to="/add" className={location.pathname === '/add' ? 'active' : ''}>
               {i.add}
@@ -90,6 +94,7 @@ export default function App() {
           <Route path="/add" element={<RecipeForm lang={lang} />} />
           <Route path="/edit/:id" element={<RecipeForm lang={lang} />} />
           <Route path="/import" element={<ImportPage lang={lang} />} />
+          <Route path="/pantry" element={<PantryPage lang={lang} />} />
           <Route
             path="/cart"
             element={

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -24,6 +24,25 @@ export async function fetchTags(lang = 'en') {
   return checkResponse(res);
 }
 
+export async function fetchPantryRecipes({ ingredients = [], page = 1, limit = 24, lang = 'en' } = {}) {
+  const params = new URLSearchParams();
+  params.set('ingredients', ingredients.join(','));
+  params.set('page', page);
+  params.set('limit', limit);
+  params.set('lang', lang);
+  const res = await fetch(`${BASE}/recipes/pantry?${params}`);
+  return checkResponse(res);
+}
+
+export async function fetchIngredientNames({ q, lang = 'en', limit = 10 } = {}) {
+  const params = new URLSearchParams();
+  params.set('q', q);
+  params.set('lang', lang);
+  params.set('limit', limit);
+  const res = await fetch(`${BASE}/recipes/ingredient-names?${params}`);
+  return checkResponse(res);
+}
+
 export async function fetchRecipe(id) {
   const res = await fetch(`${BASE}/recipes/${id}`);
   return checkResponse(res);

--- a/client/src/i18n.js
+++ b/client/src/i18n.js
@@ -4,6 +4,16 @@ const translations = {
     recipes: 'Recipes',
     add: '+ Add',
     import: 'Import',
+    pantry: 'Pantry',
+
+    // PantryPage
+    pantryTitle: 'Cook with what you have',
+    pantryDescription: 'Add ingredients you have on hand. Recipes need to contain all of them.',
+    pantryInputPlaceholder: 'Type an ingredient (e.g. ground beef)',
+    addToPantry: '+ Add',
+    findRecipes: 'Find recipes',
+    pantryNoIngredients: 'Add at least one ingredient to start.',
+    noPantryResults: 'No recipes contain all of those ingredients. Try removing one.',
 
     // RecipeList
     heroTitle: 'What do you feel like cooking?',
@@ -120,6 +130,16 @@ const translations = {
     recipes: 'Recettes',
     add: '+ Ajouter',
     import: 'Importer',
+    pantry: 'Garde-manger',
+
+    // PantryPage
+    pantryTitle: 'Cuisiner avec ce que vous avez',
+    pantryDescription: 'Ajoutez des ingredients que vous avez sous la main. Les recettes doivent tous les contenir.',
+    pantryInputPlaceholder: 'Tapez un ingredient (ex. boeuf hache)',
+    addToPantry: '+ Ajouter',
+    findRecipes: 'Trouver des recettes',
+    pantryNoIngredients: 'Ajoutez au moins un ingredient pour commencer.',
+    noPantryResults: 'Aucune recette ne contient tous ces ingredients. Essayez d\'en retirer un.',
 
     // RecipeList
     heroTitle: "Qu'avez-vous envie de cuisiner?",

--- a/client/src/pages/PantryPage.jsx
+++ b/client/src/pages/PantryPage.jsx
@@ -1,0 +1,243 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { fetchPantryRecipes, fetchIngredientNames } from '../api';
+import { t as getT } from '../i18n';
+
+export default function PantryPage({ lang }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const ingredientsParam = searchParams.get('ingredients') || '';
+  const selected = ingredientsParam
+    ? ingredientsParam.split(',').map((s) => s.trim()).filter(Boolean)
+    : [];
+  const page = parseInt(searchParams.get('page') || '1');
+
+  const [inputValue, setInputValue] = useState('');
+  const [suggestions, setSuggestions] = useState([]);
+  const [results, setResults] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const i = getT(lang);
+  const debounceRef = useRef(null);
+  const datalistId = 'pantry-ingredient-suggestions';
+
+  const updateParams = useCallback((updates) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      for (const [key, value] of Object.entries(updates)) {
+        if (value === null || value === '' || (value === '1' && key === 'page')) {
+          next.delete(key);
+        } else {
+          next.set(key, value);
+        }
+      }
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
+
+  const setSelected = useCallback((list) => {
+    updateParams({ ingredients: list.join(',') || null, page: '1' });
+  }, [updateParams]);
+
+  const addIngredient = (raw) => {
+    const value = raw.trim().toLowerCase();
+    if (!value) return;
+    if (selected.some((s) => s.toLowerCase() === value)) {
+      setInputValue('');
+      return;
+    }
+    setSelected([...selected, value]);
+    setInputValue('');
+    setSuggestions([]);
+  };
+
+  const removeIngredient = (name) => {
+    setSelected(selected.filter((s) => s !== name));
+  };
+
+  // Debounced autocomplete
+  useEffect(() => {
+    if (!inputValue.trim()) {
+      setSuggestions([]);
+      return;
+    }
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      fetchIngredientNames({ q: inputValue.trim(), lang, limit: 10 })
+        .then((rows) => setSuggestions(rows))
+        .catch(() => setSuggestions([]));
+    }, 200);
+    return () => clearTimeout(debounceRef.current);
+  }, [inputValue, lang]);
+
+  // Reset when language changes
+  const prevLangRef = useRef(lang);
+  useEffect(() => {
+    if (prevLangRef.current !== lang) {
+      prevLangRef.current = lang;
+      setSearchParams({}, { replace: true });
+      setResults(null);
+      setInputValue('');
+      setSuggestions([]);
+    }
+  }, [lang, setSearchParams]);
+
+  // Run search when selected ingredients or page change
+  useEffect(() => {
+    if (selected.length === 0) {
+      setResults(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    fetchPantryRecipes({ ingredients: selected, page, lang })
+      .then((data) => setResults(data))
+      .catch((err) => {
+        setError(err.message);
+        setResults(null);
+      })
+      .finally(() => setLoading(false));
+  }, [ingredientsParam, page, lang]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (inputValue.trim()) addIngredient(inputValue);
+  };
+
+  return (
+    <div>
+      <div className="search-hero search-hero--compact">
+        <h2 className="search-hero-title">{i.pantryTitle}</h2>
+        <p style={{ color: 'var(--text-light)', marginBottom: '16px' }}>{i.pantryDescription}</p>
+
+        <form onSubmit={handleSubmit} className="search-form">
+          <input
+            type="text"
+            className="search-input"
+            placeholder={i.pantryInputPlaceholder}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            list={datalistId}
+            autoFocus
+          />
+          <datalist id={datalistId}>
+            {suggestions.map((s) => (
+              <option key={s.name} value={s.name}>{`${s.name} (${s.count})`}</option>
+            ))}
+          </datalist>
+          <button type="submit" className="btn btn-primary search-btn" disabled={!inputValue.trim()}>
+            {i.addToPantry}
+          </button>
+        </form>
+
+        {selected.length > 0 && (
+          <div className="filter-section">
+            <div className="filter-chips">
+              {selected.map((name) => (
+                <button
+                  key={name}
+                  type="button"
+                  className="chip chip--active"
+                  onClick={() => removeIngredient(name)}
+                  title={i.remove}
+                >
+                  {name} <span aria-hidden="true">×</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {loading && (
+        <p style={{ padding: '40px 0', textAlign: 'center', color: 'var(--text-light)' }}>
+          {i.searching}
+        </p>
+      )}
+
+      {error && (
+        <p style={{ padding: '40px 0', textAlign: 'center', color: 'var(--danger)' }}>
+          {error}
+        </p>
+      )}
+
+      {!loading && selected.length === 0 && (
+        <p style={{ padding: '40px 0', textAlign: 'center', color: 'var(--text-light)', fontSize: '0.95rem' }}>
+          {i.pantryNoIngredients}
+        </p>
+      )}
+
+      {!loading && selected.length > 0 && results && (
+        <>
+          <div className="results-header">
+            <span className="results-count">{i.found(results.total)}</span>
+            <button
+              className="btn btn-outline btn-sm"
+              onClick={() => {
+                setSearchParams({}, { replace: true });
+                setResults(null);
+              }}
+            >
+              {i.clearAll}
+            </button>
+          </div>
+
+          {results.recipes.length === 0 ? (
+            <p style={{ padding: '40px 0', textAlign: 'center', color: 'var(--text-light)' }}>
+              {i.noPantryResults}
+            </p>
+          ) : (
+            <div className="recipe-grid">
+              {results.recipes.map((recipe) => (
+                <div key={recipe.id} className="recipe-card">
+                  <Link to={`/recipe/${recipe.id}`}>
+                    {recipe.imageUrl ? (
+                      <img src={recipe.imageUrl} alt={recipe.title} loading="lazy" />
+                    ) : (
+                      <div className="no-image">{recipe.title.charAt(0)}</div>
+                    )}
+                    <div className="recipe-card-body">
+                      <h3>{recipe.title}</h3>
+                      <p>{recipe.description}</p>
+                      <div className="recipe-card-meta">
+                        {recipe.totalTime && <span>{recipe.totalTime.replace('PT', '').replace('M', ' min')}</span>}
+                        {recipe.servings && <span>{i.servings(recipe.servings)}</span>}
+                        {recipe.difficulty && <span>{recipe.difficulty}</span>}
+                      </div>
+                      {recipe.tags?.length > 0 && (
+                        <div className="tags-list">
+                          {recipe.tags.slice(0, 4).map((tag) => (
+                            <span key={tag} className="tag">{tag}</span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </Link>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {results.totalPages > 1 && (
+            <div className="pagination">
+              <button
+                className="btn btn-outline btn-sm"
+                disabled={page <= 1}
+                onClick={() => updateParams({ page: String(page - 1) })}
+              >
+                {i.previous}
+              </button>
+              <span className="page-info">{i.page(results.page, results.totalPages)}</span>
+              <button
+                className="btn btn-outline btn-sm"
+                disabled={page >= results.totalPages}
+                onClick={() => updateParams({ page: String(page + 1) })}
+              >
+                {i.next}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/docs/superpowers/specs/2026-05-14-pantry-ingredient-search-design.md
+++ b/docs/superpowers/specs/2026-05-14-pantry-ingredient-search-design.md
@@ -1,0 +1,147 @@
+# Pantry Ingredient Search — Design
+
+**Date**: 2026-05-14
+**Status**: Approved, ready for implementation
+**Scope**: New `/pantry` page that finds recipes containing a user-supplied set of ingredients (AND logic).
+
+## Goal
+
+Answer the question "what can I cook with what I have on hand?". User types ingredients they have (e.g. *ground beef*, *cheddar*), and the app returns only recipes whose ingredient list contains **all** of them.
+
+The existing global search (`GET /api/recipes?search=…`) already searches across title/description/cuisine/ingredients, but it is keyword-style: it doesn't constrain to the ingredient list, and it can't separate ingredients from incidental matches in the description. The pantry view solves a different, narrower problem and gets its own page.
+
+## Non-goals
+
+- Substitution suggestions ("you're missing one ingredient, here's a near-match")
+- Dietary filters in this iteration (combining with tags/cuisines is deferred)
+- Quantity-aware matching (we only check name presence)
+- Pantry persistence per user (no auth in the app, no profile)
+
+## UX
+
+**Route**: `/pantry`
+
+**Layout**:
+1. Heading + short description ("Add ingredients you have on hand. Recipes need to contain all of them.")
+2. Ingredient input — a single text input with autocomplete (HTML `<datalist>` or a small custom list)
+3. Selected ingredients shown as removable chips below the input
+4. Primary button "Find recipes" (also triggered on Enter when chips are present)
+5. Results grid — same recipe-card style as `RecipeList`, with pagination
+
+**URL sync**: `?ingredients=ground+beef,cheddar&page=2`. Reloading or sharing the URL restores the state.
+
+**Language**: Uses the global `lang` prop already plumbed through `App.jsx`. Pantry matches only recipes in the current language (consistent with the existing search).
+
+**i18n**: New translation keys (`pantry`, `pantryTitle`, `pantryDescription`, `addIngredient`, `findRecipes`, `noPantryResults`, `pantryNoIngredients`) added to both `en` and `fr` blocks.
+
+**Nav**: New top-nav link "Pantry" / "Garde-manger" alongside Home / Import / Shopping List.
+
+## Backend
+
+Two new endpoints, both in `server/routes/recipes.js`:
+
+### `GET /api/recipes/pantry`
+
+Query params:
+- `ingredients` (required) — comma-separated list. Each item is trimmed and lowercased server-side. Empty list returns `{ recipes: [], total: 0 }`.
+- `lang` (validated via `langSchema`, defaults to `en`)
+- `page`, `limit` — same defaults/caps as `GET /api/recipes` (page 1, limit 24, max 60)
+
+Behavior:
+- Build a Prisma `where` clause:
+  ```js
+  where: {
+    language: lang,
+    AND: ingredients.map((name) => ({
+      ingredients: { some: { name: { contains: name, mode: 'insensitive' } } },
+    })),
+  }
+  ```
+- Each `some` translates to an `EXISTS` subquery. The AND between them enforces "every ingredient must appear in this recipe".
+- Same pagination shape as the existing list endpoint: `{ recipes, total, page, totalPages }`.
+
+### `GET /api/recipes/ingredient-names`
+
+Query params:
+- `q` (required, min length 1)
+- `lang`
+- `limit` (default 10, max 20)
+
+Behavior:
+- Returns distinct ingredient names that start with or contain `q` (case-insensitive), scoped to recipes in `lang`. Most-frequent names first.
+- Implementation via `prisma.$queryRaw` joining Ingredient → Recipe so we can filter on `Recipe.language` and dedupe + sort by count in one query:
+  ```sql
+  SELECT i.name, COUNT(*)::int AS count
+  FROM "Ingredient" i
+  JOIN "Recipe" r ON r.id = i."recipeId"
+  WHERE r.language = ${lang}
+    AND i.name ILIKE ${'%' + q + '%'}
+  GROUP BY i.name
+  ORDER BY count DESC
+  LIMIT ${limit};
+  ```
+
+Performance note: with the current dataset size (< 10k recipes), `ILIKE '%q%'` is acceptable. If the dataset grows materially, a `pg_trgm` GIN index on `Ingredient.name` is the upgrade path. Out of scope for this PR.
+
+## Frontend
+
+### New file: `client/src/pages/PantryPage.jsx`
+
+State:
+- `inputValue` (string, current text in the input)
+- `suggestions` (array of `{ name, count }` from the autocomplete endpoint, debounced)
+- `selected` (array of strings — ingredients chosen, synced to URL)
+- `results`, `loading`, `error` (standard pattern from `RecipeList`)
+
+Behavior:
+- Debounce input changes (200 ms) → call `fetchIngredientNames`. Render suggestions in a `<datalist>` linked to the input.
+- Pressing Enter or clicking "Add" with non-empty input appends to `selected`, clears the input. Adding an already-present chip is a no-op.
+- Clicking the × on a chip removes it.
+- "Find recipes" → calls `fetchPantryRecipes`, sets `results`, updates URL.
+- Empty selection state shows a tip card ("Add an ingredient to start").
+
+### Updates to `client/src/api.js`
+
+Two new functions:
+- `fetchPantryRecipes({ ingredients, page, limit, lang })`
+- `fetchIngredientNames({ q, lang, limit })`
+
+### Updates to `client/src/App.jsx`
+
+- Add `<Route path="/pantry" element={<PantryPage lang={lang} />} />`
+- Add a nav link.
+
+### Updates to `client/src/i18n.js`
+
+- Add the new keys listed in the UX section to both `en` and `fr`.
+
+## Data model
+
+No schema migrations. The existing `Ingredient` model + `Recipe.ingredients` relation is sufficient.
+
+## Failure modes & edge cases
+
+| Case | Behavior |
+|------|----------|
+| Empty `ingredients` param | Return `{ recipes: [], total: 0, page: 1, totalPages: 0 }` (mirrors `GET /api/recipes` no-query behavior) |
+| Single ingredient | Works — one `AND` entry |
+| Ingredient with comma (e.g. `"salt, pepper"`) | We split on `,` so this becomes two entries. Acceptable for v1; users typically type one ingredient per chip anyway. |
+| Very common term (`salt`) | Will match a lot. AND with another chip narrows it. UI shows total count so the user can refine. |
+| Autocomplete `q` shorter than 1 char | Return empty list |
+| Language mismatch (FR recipe, EN ingredient name) | Returns no results — expected, matches existing search behavior |
+
+## Test plan (manual)
+
+- [ ] Navigate to `/pantry`, see empty-state message
+- [ ] Type `che` → datalist shows `cheddar`, `cheese`, etc., ordered by count
+- [ ] Add `ground beef` and `cheddar` → click Find → results only contain recipes with both
+- [ ] Remove `cheddar` chip → click Find → broader result set
+- [ ] Reload page with `?ingredients=ground+beef,cheddar` → state restored, results shown
+- [ ] Switch language → list scopes to current lang
+- [ ] Pagination works
+
+## Out-of-PR follow-ups (NOT in this PR)
+
+- Tag/cuisine filter combination
+- `pg_trgm` index for autocomplete at scale
+- Persistent pantry per user (would need auth)

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -52,6 +52,82 @@ router.get('/tags', async (req, res) => {
   }
 });
 
+// Pantry search: find recipes containing ALL of the listed ingredients.
+// Example: GET /api/recipes/pantry?ingredients=ground+beef,cheddar&lang=en
+router.get('/pantry', async (req, res) => {
+  try {
+    const lang = langSchema.parse(req.query.lang);
+    const { page = '1', limit = '24' } = req.query;
+    const raw = (req.query.ingredients || '').toString();
+
+    const ingredients = raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    if (ingredients.length === 0) {
+      return res.json({ recipes: [], total: 0, page: 1, totalPages: 0 });
+    }
+
+    const pageNum = Math.max(1, parseInt(page));
+    const pageSize = Math.min(60, Math.max(1, parseInt(limit)));
+    const skip = (pageNum - 1) * pageSize;
+
+    const where = {
+      language: lang,
+      AND: ingredients.map((name) => ({
+        ingredients: { some: { name: { contains: name, mode: 'insensitive' } } },
+      })),
+    };
+
+    const [recipes, total] = await Promise.all([
+      prisma.recipe.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: pageSize,
+      }),
+      prisma.recipe.count({ where }),
+    ]);
+
+    res.json({
+      recipes,
+      total,
+      page: pageNum,
+      totalPages: Math.ceil(total / pageSize),
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Ingredient-name autocomplete for the pantry search.
+// Returns distinct names matching q (case-insensitive substring), most frequent first.
+router.get('/ingredient-names', async (req, res) => {
+  try {
+    const lang = langSchema.parse(req.query.lang);
+    const q = (req.query.q || '').toString().trim();
+    if (!q) return res.json([]);
+
+    const limit = Math.min(20, Math.max(1, parseInt(req.query.limit) || 10));
+    const pattern = `%${q}%`;
+
+    const rows = await prisma.$queryRaw`
+      SELECT i.name, COUNT(*)::int AS count
+      FROM "Ingredient" i
+      JOIN "Recipe" r ON r.id = i."recipeId"
+      WHERE r.language = ${lang}
+        AND i.name ILIKE ${pattern}
+      GROUP BY i.name
+      ORDER BY count DESC, i.name ASC
+      LIMIT ${limit}
+    `;
+    res.json(rows);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Search recipes (returns nothing if no query)
 router.get('/', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- New `/pantry` page: pick the ingredients you have, get back recipes that contain **all** of them.
- Two new backend endpoints under `/api/recipes`:
  - `GET /pantry?ingredients=a,b&lang=&page=&limit=`
  - `GET /ingredient-names?q=&lang=&limit=` for the autocomplete datalist (most-frequent names first).
- Frontend: `PantryPage.jsx`, two API helpers in `api.js`, nav link + route in `App.jsx`, EN/FR keys in `i18n.js`.
- Design doc: `docs/superpowers/specs/2026-05-14-pantry-ingredient-search-design.md`.

## Design choices (per brainstorm)
- **AND strict** across ingredients — each chip is a separate `ingredients: { some: { name: { contains, mode: insensitive } } }` so Postgres runs one EXISTS per chip.
- **Partial case-insensitive match** — `cheddar` matches `cheddar cheese`, `sharp cheddar`, etc.
- **Tags/chips with autocomplete from DB** — `$queryRaw` joins Ingredient + Recipe, groups by name, orders by count, filters by language.
- No new schema. URL-synced state. Language scoping consistent with existing search.

## Test plan
- [ ] `npm install && npm run dev` and visit `/pantry`
- [ ] Type `che` → datalist shows real ingredient names with counts
- [ ] Add `ground beef` + `cheddar` → only recipes with both appear
- [ ] Remove `cheddar` → broader set
- [ ] Reload with `?ingredients=ground+beef,cheddar` → state restored
- [ ] Switch EN/FR → scope updates, labels translate
- [ ] Pagination works on large result sets

## Out of scope (future PRs)
- Tag/cuisine combinations on /pantry
- `pg_trgm` GIN index if dataset grows materially
- Persistent pantry per user (would need auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)